### PR TITLE
Payload size is just the image data size

### DIFF
--- a/src/ttblit/asset/image.py
+++ b/src/ttblit/asset/image.py
@@ -96,7 +96,7 @@ class ImageAsset(AssetBuilder):
 
         palette_size = struct.pack('<B', len(self.palette))
 
-        payload_size = struct.pack('<H', len(image_data) + len(palette_data) + header_size)
+        payload_size = struct.pack('<H', len(image_data))
         image_size = struct.pack('<HH', *image.size)
 
         data = bytes('SPRITEPK' if self.packed else 'SPRITERW', encoding='utf-8')


### PR DESCRIPTION
Currently `load_from_packed` is reading past the end of the buffer. (Noticed as I use `-fsanitize=address` on local debug builds.)

Also, should sprites default to packed? I just spent a while debugging `load_from_packed`, then realised I was trying to load a raw sprite... 