### PR TITLE
Support raw, headerless image output

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ python3 setup.py develop
 
 All image assets are handled by Pillow so most image formats will work, be careful with lossy formats since they may add unwanted colours to your palette and leave you with oversized assets.
 
+By default images will be packed into bits depending on the palette size. A 16-colour palette would use 4-bits-per-pixel. Use `--raw` to output raw pixel data, suitable for loading directly into a `blit::Surface`.
+
 Supported formats:
 
 * 8bit PNG .png
@@ -36,7 +38,8 @@ Options:
 
 * `palette` - Image or palette file (Adobe .act, Pro Motion NG .pal, GIMP .gpl) containing the asset colour palette
 * `transparent` - Transparent colour (if palette isn't an RGBA image), should be either hex (FFFFFF) or R,G,B (255,255,255)
-* `packed` - (Defaults to true) will pack the output asset into bits depending on the palette size. A 16-colour palette would use 4-bits-per-pixel.
+* `raw` - Output raw pixel data, suitable for loading into a `blit::Surface`
+* `raw_format` - Format for raw data, either RGB or RGBA
 * `strict` - Only allow colours that are present in the palette image/file
 
 ## Packing Map Assets

--- a/src/README.md
+++ b/src/README.md
@@ -27,6 +27,8 @@ python3 setup.py develop
 
 All image assets are handled by Pillow so most image formats will work, be careful with lossy formats since they may add unwanted colours to your palette and leave you with oversized assets.
 
+By default images will be packed into bits depending on the palette size. A 16-colour palette would use 4-bits-per-pixel. Use `--raw` to output raw pixel data, suitable for loading directly into a `blit::Surface`.
+
 Supported formats:
 
 * 8bit PNG .png
@@ -36,7 +38,8 @@ Options:
 
 * `palette` - Image or palette file (Adobe .act, Pro Motion NG .pal, GIMP .gpl) containing the asset colour palette
 * `transparent` - Transparent colour (if palette isn't an RGBA image), should be either hex (FFFFFF) or R,G,B (255,255,255)
-* `packed` - (Defaults to true) will pack the output asset into bits depending on the palette size. A 16-colour palette would use 4-bits-per-pixel.
+* `raw` - Output raw pixel data, suitable for loading into a `blit::Surface`
+* `raw_format` - Format for raw data, either RGB or RGBA
 * `strict` - Only allow colours that are present in the palette image/file
 
 ## Packing Map Assets

--- a/src/tests/test_image_cli.py
+++ b/src/tests/test_image_cli.py
@@ -50,7 +50,7 @@ def test_image_png_cli_unpacked(parsers, test_input_file):
 
     image = image.ImageAsset(subparser)
 
-    args = parser.parse_args(['image', '--input_file', test_input_file.name, '--packed', 'no', '--output_format', 'c_header'])
+    args = parser.parse_args(['image', '--input_file', test_input_file.name, '--raw', '--raw_format', 'RGBA', '--output_format', 'c_header'])
 
     image.run(args)
 
@@ -62,7 +62,7 @@ def test_image_png_cli_packed(parsers, test_input_file):
 
     image = image.ImageAsset(subparser)
 
-    args = parser.parse_args(['image', '--input_file', test_input_file.name, '--packed', '--output_format', 'c_header'])
+    args = parser.parse_args(['image', '--input_file', test_input_file.name, '--output_format', 'c_header'])
 
     image.run(args)
 

--- a/src/ttblit/asset/image.py
+++ b/src/ttblit/asset/image.py
@@ -20,7 +20,8 @@ class ImageAsset(AssetBuilder):
         self.options.update({
             'palette': (Palette, Palette()),
             'transparent': Colour,
-            'packed': (str, 'yes'),
+            'raw': (bool, False),
+            'raw_format': (str, 'RGBA'),
             'strict': (bool, False)
         })
 
@@ -28,19 +29,18 @@ class ImageAsset(AssetBuilder):
 
         self.palette = None
         self.transparent = None
-        self.packed = True
+        self.raw = False
+        self.raw_format = 'RGBA'
         self.strict = False
 
         self.parser.add_argument('--palette', type=type_palette, default=None, help='Image or palette file of colours to use')
         self.parser.add_argument('--transparent', type=Colour, help='Transparent colour')
-        self.parser.add_argument('--packed', type=str, nargs='?', default='yes', choices=('yes', 'no'), help='Pack into bits depending on palette colour count')
+        self.parser.add_argument('--raw', action='store_true', help='Output just raw binary data')
+        self.parser.add_argument('--raw_format', type=str, help='Raw output format', choices=('RGB', 'RGBA'), default='RGBA')
         self.parser.add_argument('--strict', action='store_true', help='Reject colours not in the palette')
 
     def prepare(self, args):
         AssetBuilder.prepare(self, args)
-
-        if type(self.packed) is not bool:
-            self.packed = self.packed == 'yes'
 
         if self.transparent is not None:
             r, g, b = self.transparent
@@ -53,10 +53,11 @@ class ImageAsset(AssetBuilder):
     def quantize_image(self, input_data):
         if self.strict and len(self.palette) == 0:
             raise TypeError("Attempting to enforce strict colours with an empty palette, did you really want to do this?")
-        # Since we already have bytes, we need to pass PIL an io.BytesIO object
-        image = Image.open(io.BytesIO(input_data)).convert('RGBA')
+
+        image = self.load_image(input_data)
         w, h = image.size
         output_image = Image.new('P', (w, h))
+
         for y in range(h):
             for x in range(w):
                 r, g, b, a = image.getpixel((x, y))
@@ -67,33 +68,38 @@ class ImageAsset(AssetBuilder):
 
         return output_image
 
+    def load_image(self, input_data):
+        # Since we already have bytes, we need to pass PIL an io.BytesIO object
+        return Image.open(io.BytesIO(input_data)).convert('RGBA')
+
     def to_binary(self, input_data):
-        image = self.quantize_image(input_data)
+        if self.raw:
+            return self.load_image(input_data).tobytes()
 
-        # TODO Image format needs rewriting to support more than 255 palette entries, this is a bug!
-        # This fix allows `test_image_png_cli_strict_palette_pal` to pass.
-        self.palette.entries = self.palette.entries[:255]
+        else:
+            image = self.quantize_image(input_data)
 
-        palette_data = self.palette.tobytes()
+            # TODO Image format needs rewriting to support more than 255 palette entries, this is a bug!
+            # This fix allows `test_image_png_cli_strict_palette_pal` to pass.
+            self.palette.entries = self.palette.entries[:255]
 
-        if self.packed:
+            palette_data = self.palette.tobytes()
+
             bit_length = self.palette.bit_length()
             image_data = BitArray().join(BitArray(uint=x, length=bit_length) for x in image.tobytes()).tobytes()
-        else:
-            image_data = image.tobytes()
 
-        palette_size = struct.pack('<B', len(self.palette))
+            palette_size = struct.pack('<B', len(self.palette))
 
-        payload_size = struct.pack('<H', len(image_data))
-        image_size = struct.pack('<HH', *image.size)
+            payload_size = struct.pack('<H', len(image_data))
+            image_size = struct.pack('<HH', *image.size)
 
-        data = bytes('SPRITEPK' if self.packed else 'SPRITERW', encoding='utf-8')
-        data += payload_size
-        data += image_size
-        data += bytes([0x10, 0x00, 0x10, 0x00])  # Rows/cols deprecated
-        data += b'\x02'                          # Pixel format
-        data += palette_size
-        data += palette_data
-        data += image_data
+            data = bytes('SPRITEPK', encoding='utf-8')
+            data += payload_size
+            data += image_size
+            data += bytes([0x10, 0x00, 0x10, 0x00])  # Rows/cols deprecated
+            data += b'\x02'                          # Pixel format
+            data += palette_size
+            data += palette_data
+            data += image_data
 
-        return data
+            return data


### PR DESCRIPTION
This set of changes removes the `packed` flag, which should be the default behaviour, and replaces it with a `raw` flag which, when supplied, causes the image packing tool to output raw RGB or RGBA values with no header. Raw image data can be used to initalise a surface and should not be loaded with `SpriteSheet::load`.