### PR TITLE
Prefix palette with working dir for #15

### DIFF
--- a/src/tests/test_packer_cli.py
+++ b/src/tests/test_packer_cli.py
@@ -1,0 +1,92 @@
+import argparse
+import base64
+import tempfile
+import pathlib
+
+import pytest
+
+
+@pytest.fixture
+def parsers():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--debug', action='store_true', help='Enable exception traces')
+    return parser, parser.add_subparsers(dest='command', help='Commands')
+
+
+@pytest.fixture
+def png_file():
+    temp_png = tempfile.NamedTemporaryFile('wb', suffix='.png')
+    temp_png.write(base64.b64decode(b'iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAMAAAD04JH5AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyNpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMTQ4IDc5LjE2NDAzNiwgMjAxOS8wOC8xMy0wMTowNjo1NyAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIDIxLjAgKFdpbmRvd3MpIiB4bXBNTTpJbnN0YW5jZUlEPSJ4bXAuaWlkOjE5NkU4OENBNTk3NDExRUFCMTgyODFBRDFGMTZDODJGIiB4bXBNTTpEb2N1bWVudElEPSJ4bXAuZGlkOjE5NkU4OENCNTk3NDExRUFCMTgyODFBRDFGMTZDODJGIj4gPHhtcE1NOkRlcml2ZWRGcm9tIHN0UmVmOmluc3RhbmNlSUQ9InhtcC5paWQ6MTk2RTg4Qzg1OTc0MTFFQUIxODI4MUFEMUYxNkM4MkYiIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6MTk2RTg4Qzk1OTc0MTFFQUIxODI4MUFEMUYxNkM4MkYiLz4gPC9yZGY6RGVzY3JpcHRpb24+IDwvcmRmOlJERj4gPC94OnhtcG1ldGE+IDw/eHBhY2tldCBlbmQ9InIiPz4ohDCNAAAACVBMVEUAAAD///8A/wDg4n4DAAAAmklEQVR42uzZMQqAMAxA0er9D+1Wl1ITijTi+6PQ8qYYsTVJUu/Ilj569gAAAABqAtIDM30UAAAAoDrAuwAAAODLK9nCdAQAAACoBHh/FD84AQAAALYDJEnpQTk6MPgCD98LAAAAUAiQXkXT9wIAAADUBEx/qEQBg2fhUQwAAAAAAAAAAHADFnbCKSC8EwIAAABsAkjST7sEGACd4xph9WtahAAAAABJRU5ErkJggg=='))
+    temp_png.flush()
+    return temp_png
+
+
+@pytest.fixture
+def output_dir():
+    temp_output = tempfile.NamedTemporaryFile('w', suffix='.hpp')
+    return pathlib.Path(temp_output.name).parents[0]
+
+
+@pytest.fixture
+def palette_file():
+    temp_pal = tempfile.NamedTemporaryFile('wb', suffix='.act')
+    temp_pal.write(b'\x00\x00\x00')  # Write black colour
+    temp_pal.write(b'\x00\xff\x00')  # Write green colour
+    temp_pal.write(b'\xff\xff\xff')  # Write white colour
+    temp_pal.write(b'\x00' * 759)  # Pad to 772 bytes
+    temp_pal.write(b'\x00\x03')  # Write size
+    temp_pal.write(b'\x00\x00')  # Ignored bytes
+    temp_pal.flush()
+    return temp_pal
+
+
+@pytest.fixture
+def yml_file_relative_paths(png_file, palette_file):
+    png_file = pathlib.Path(png_file.name)
+    palette_file = pathlib.Path(palette_file.name)
+    temp_yml = tempfile.NamedTemporaryFile('w', suffix='.yml')
+    temp_yml.write(f'''assets.hpp:
+  {png_file.name}:
+    palette: {palette_file.name}
+    name: asset_test
+''')
+    temp_yml.flush()
+    return temp_yml
+
+
+@pytest.fixture
+def tools(parsers):
+    from ttblit.asset import font, image, map, raw
+
+    parser, subparser = parsers
+    tools = {}
+    tools[image.ImageAsset.command] = image.ImageAsset(subparser)
+    tools[font.FontAsset.command] = font.FontAsset(subparser)
+    tools[map.MapAsset.command] = map.MapAsset(subparser)
+    tools[raw.RawAsset.command] = raw.RawAsset(subparser)
+    return tools
+
+
+def test_packer_cli_no_args(parsers):
+    from ttblit.tool import packer
+
+    parser, subparser = parsers
+
+    packer = packer.Packer(subparser)
+
+    args = parser.parse_args(['pack'])
+
+    packer.run(args)
+
+
+def test_packer_cli_relative_yml(parsers, tools, yml_file_relative_paths, output_dir):
+    from ttblit.tool import packer
+
+    parser, subparser = parsers
+
+    packer = packer.Packer(subparser)
+    packer.register_asset_builders(tools)
+
+    args = parser.parse_args(['pack', '--force', '--config', yml_file_relative_paths.name, '--output', str(output_dir)])
+
+    packer.run(args)

--- a/src/ttblit/tool/packer.py
+++ b/src/ttblit/tool/packer.py
@@ -3,6 +3,7 @@ import pathlib
 import yaml
 
 from ..core.outputformat import CHeader, CSource, RawBinary
+from ..core.palette import Palette
 from ..core.tool import Tool
 
 
@@ -108,12 +109,8 @@ class Packer(Tool):
                 elif file_options is None:
                     file_options = {}
 
-                if 'palette' in file_options:
-                    if not pathlib.Path(file_options['palette']).is_absolute():
-                        file_options['palette'] = self.working_path / file_options['palette']
-
                 asset_sources.append(
-                    AssetSource(input_files, builders=self.asset_builders, file_options=file_options)
+                    AssetSource(input_files, builders=self.asset_builders, file_options=file_options, working_path=self.working_path)
                 )
 
             self.assets.append(AssetTarget(
@@ -132,9 +129,10 @@ class Packer(Tool):
 class AssetSource():
     supported_options = ('name', 'type')
 
-    def __init__(self, input_files, builders, file_options):
+    def __init__(self, input_files, builders, file_options, working_path):
         self.input_files = input_files
         self.asset_builders = builders
+        self.working_path = working_path
         self.builder_options = {}
         self.type = None
         self.name = None
@@ -165,6 +163,21 @@ class AssetSource():
     def build(self, format, prefix=None, output_file=None):
         builder, input_type = self.type.split('/')
         builder = self.asset_builders[builder]
+
+        # Now we know our target builder, one last iteration through the options
+        # allows some pre-processing stages to remap paths or other idiosyncrasies
+        # of the yml config format.
+        for option_name, option_value in builder.options.items():
+            if option_name in self.builder_options:
+                option_type = builder.options[option_name]
+                if type(option_type) is tuple:
+                    option_type, default_value = option_type
+
+                # Ensure Palette and pathlib.Path type options for this asset builder
+                # are prefixed with the working directory if they are not absolute paths
+                if option_type in (Palette, pathlib.Path):
+                    if not pathlib.Path(self.builder_options[option_name]).is_absolute():
+                        self.builder_options[option_name] = self.working_path / self.builder_options[option_name]
 
         output = []
 

--- a/src/ttblit/tool/packer.py
+++ b/src/ttblit/tool/packer.py
@@ -108,6 +108,10 @@ class Packer(Tool):
                 elif file_options is None:
                     file_options = {}
 
+                if 'palette' in file_options:
+                    if not pathlib.Path(file_options['palette']).is_absolute():
+                        file_options['palette'] = self.working_path / file_options['palette']
+
                 asset_sources.append(
                     AssetSource(input_files, builders=self.asset_builders, file_options=file_options)
                 )


### PR DESCRIPTION
Adds a test for the packer with paths relative to the working directory, and fixes it by catching the "palette" option and prefixing it with the working directory if it is not an absolute path.

This is one to expand in future, since there may be other filename/path option supplied to future asset builders that could fail in the same way.

Should fix #15!