### PR TITLE
Add author field, prefix metadata fields

### DIFF
--- a/src/tests/test_metadata.py
+++ b/src/tests/test_metadata.py
@@ -37,6 +37,7 @@ def test_metadata_file():
     temp_yml = tempfile.NamedTemporaryFile('w', suffix='.yml')
     temp_yml.write(f'''title: Rocks & Diamonds
 description: A pulse pounding, rock rollin', diamond hunting adventure
+author: gadgetoid
 splash:
   file: {temp_png.name}
 version: v1.0.0

--- a/src/ttblit/tool/metadata.py
+++ b/src/ttblit/tool/metadata.py
@@ -24,7 +24,7 @@ class Metadata(Tool):
         config = open(config_file).read()
         config = yaml.safe_load(config)
 
-        required = ['title', 'description', 'version']
+        required = ['title', 'description', 'version', 'author']
 
         for option in required:
             if option not in config:
@@ -90,19 +90,24 @@ class Metadata(Tool):
         title = bytes(self.config.get('title').encode('utf-8'))
         description = bytes(self.config.get('description').encode('utf-8'))
         version = bytes(self.config.get('version').encode('utf-8'))
+        author = bytes(self.config.get('author').encode('utf-8'))
 
-        if len(title) > 64:
-            raise ValueError('Title should be a maximum of 64 characters!"')
+        if len(title) > 24:
+            raise ValueError('Title should be a maximum of 24 characters!"')
 
-        if len(description) > 1024:
-            raise ValueError('Description should be a maximum of 1024 characters!')
+        if len(description) > 128:
+            raise ValueError('Description should be a maximum of 128 characters!')
 
         if len(version) > 16:
             raise ValueError('Version should be a maximum of 16 characters! eg: "v1.0.2"')
 
-        metadata = title + eof
-        metadata += description + eof
-        metadata += version + eof
+        if len(author) > 16:
+            raise ValueError('Author should be a maximum of 16 characters!')
+
+        metadata = b'T' + title + eof
+        metadata += b'D' + description + eof
+        metadata += b'V' + version + eof
+        metadata += b'A' + author + eof
         metadata += icon
         metadata += splash
 

--- a/src/ttblit/tool/metadata.py
+++ b/src/ttblit/tool/metadata.py
@@ -53,9 +53,9 @@ class Metadata(Tool):
 
     def run(self, args):
         self.working_path = pathlib.Path('.')
-        game_header = 'BLIT'.encode('utf-8')
-        meta_header = 'BLITMETA'.encode('utf-8')
-        eof = '\0'.encode('utf-8')
+        game_header = 'BLIT'.encode('ascii')
+        meta_header = 'BLITMETA'.encode('ascii')
+        eof = '\0'.encode('ascii')
         has_meta = False
 
         icon = bytes()
@@ -94,10 +94,10 @@ class Metadata(Tool):
         if 'splash' in self.config:
             splash = self.prepare_image_asset('splash', self.config['splash'])
 
-        title = self.config.get('title').encode('utf-8')
-        description = self.config.get('description').encode('utf-8')
-        version = self.config.get('version').encode('utf-8')
-        author = self.config.get('author').encode('utf-8')
+        title = self.config.get('title').encode('ascii')
+        description = self.config.get('description').encode('ascii')
+        version = self.config.get('version').encode('ascii')
+        author = self.config.get('author').encode('ascii')
 
         if len(title) > 24:
             raise ValueError('Title should be a maximum of 24 characters!"')
@@ -112,7 +112,7 @@ class Metadata(Tool):
             raise ValueError('Author should be a maximum of 16 characters!')
 
         metadata = checksum
-        metadata += datetime.now().strftime("%Y%m%dT%H%M%S").encode('utf8') + eof
+        metadata += datetime.now().strftime("%Y%m%dT%H%M%S").encode('ascii') + eof
         metadata += title.ljust(24 + 1, eof)  # Left justify and pad with null chars to string length + 1 (terminator)
         metadata += description.ljust(128 + 1, eof)
         metadata += version.ljust(16 + 1, eof)


### PR DESCRIPTION
This tweak adds "author" to the metadata.

It also prefixes each text field with a single char, denoting the field type.

I don't know if this is the best way to accomplish future expansion or additional metadata that 32blit could ignore... but at least it opens the discussion to how we deal with new text fields.

Maybe the core metadata should be more rigidly defined to make parsing cleaner/simpler - ie fixed-length fields that can be slurped into a predefined struct.

Any *extra* data could then be appended onto the end.

Nice to haves would be additional fields such as author URL and long description that are ignored by 32blit, but carried around with the .bin for display in game manager tools or web front ends.