### PR TITLE
Make 32blit tools less noisy, fixes #8

### DIFF
--- a/src/tests/test_packer_cli.py
+++ b/src/tests/test_packer_cli.py
@@ -1,7 +1,7 @@
 import argparse
 import base64
-import tempfile
 import pathlib
+import tempfile
 
 import pytest
 

--- a/src/ttblit/__init__.py
+++ b/src/ttblit/__init__.py
@@ -2,6 +2,7 @@
 __version__ = '0.0.7'
 
 import argparse
+import logging
 import pathlib
 import sys
 
@@ -10,12 +11,14 @@ from .tool import cmake, flasher, metadata, packer
 
 
 def exception_handler(exception_type, exception, traceback):
-    print(f"{type(exception).__name__}: {exception}")
+    sys.stderr.write(f"{type(exception).__name__}: {exception}\n")
+    sys.stderr.flush()
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--debug', action='store_true', help='Enable exception traces')
+    parser.add_argument('-v', '--verbosity', action='count', default=0, help='Output verbosity')
     subparsers = parser.add_subparsers(dest='command', help='Commands')
 
     if len(sys.argv) == 2:
@@ -45,7 +48,16 @@ def main():
 
     args = parser.parse_args()
 
-    if not args.debug:
+    log_format = '%(levelname)s: %(message)s'
+
+    if args.verbosity:
+        log_verbosity = min(args.verbosity, 3) - 1
+        log_level = [logging.WARNING, logging.INFO, logging.DEBUG][log_verbosity]
+        logging.basicConfig(level=log_level, format=log_format)
+
+    if args.debug:
+        logging.basicConfig(level=logging.DEBUG, format=log_format)
+    else:
         sys.excepthook = exception_handler
 
     if args.command is None:

--- a/src/ttblit/__init__.py
+++ b/src/ttblit/__init__.py
@@ -50,10 +50,9 @@ def main():
 
     log_format = '%(levelname)s: %(message)s'
 
-    if args.verbosity:
-        log_verbosity = min(args.verbosity, 3) - 1
-        log_level = [logging.WARNING, logging.INFO, logging.DEBUG][log_verbosity]
-        logging.basicConfig(level=log_level, format=log_format)
+    log_verbosity = min(args.verbosity, 3)
+    log_level = [logging.ERROR, logging.WARNING, logging.INFO, logging.DEBUG][log_verbosity]
+    logging.basicConfig(level=log_level, format=log_format)
 
     if args.debug:
         logging.basicConfig(level=logging.DEBUG, format=log_format)

--- a/src/ttblit/asset/font.py
+++ b/src/ttblit/asset/font.py
@@ -1,8 +1,9 @@
 import io
 import struct
 
-import freetype
 from PIL import Image
+
+import freetype
 
 from ..core.assetbuilder import AssetBuilder
 

--- a/src/ttblit/asset/image.py
+++ b/src/ttblit/asset/image.py
@@ -1,4 +1,5 @@
 import io
+import logging
 import struct
 
 from bitstring import BitArray
@@ -46,9 +47,9 @@ class ImageAsset(AssetBuilder):
             r, g, b = self.transparent
             p = self.palette.set_transparent_colour(r, g, b)
             if p is not None:
-                print(f'Found transparent colour ({r},{g},{b}) in palette')
+                logging.info(f'Found transparent colour ({r},{g},{b}) in palette')
             else:
-                print(f'Could not find transparent colour ({r},{g},{b}) in palette')
+                logging.warning(f'Could not find transparent colour ({r},{g},{b}) in palette')
 
     def quantize_image(self, input_data):
         if self.strict and len(self.palette) == 0:

--- a/src/ttblit/core/assetbuilder.py
+++ b/src/ttblit/core/assetbuilder.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 import re
 
@@ -86,7 +87,7 @@ class AssetBuilder(Tool):
                     else:
                         opts[option_name] = default_value
                 else:
-                    print(f'Ignoring unsupported {self.command} option {option_name}')
+                    logging.info(f'Ignoring unsupported {self.command} option {option_name}')
 
         self.prepare(opts)
 
@@ -102,7 +103,7 @@ class AssetBuilder(Tool):
             for extension in extensions:
                 if self.input_file.name.endswith(extension):
                     self.input_type = input_type
-                    print(f"Guessed type {input_type} for {self.input_file}")
+                    logging.info(f"Guessed type {input_type} for {self.input_file}")
                     return
 
         raise TypeError(f"Unable to identify type of input file {self.input_file}")
@@ -110,14 +111,14 @@ class AssetBuilder(Tool):
     def _guess_format(self):
         if self.output_file is None:
             self.output_format = self.no_output_file_default_format
-            print(f"No --output given, writing to stdout assuming {self.no_output_file_default_format.name}")
+            logging.warning(f"No --output given, writing to stdout assuming {self.no_output_file_default_format.name}")
             return
 
         for format_name, format_class in self.formats.items():
             for extension in format_class.extensions:
                 if self.output_file.name.endswith(extension):
                     self.output_format = format_class
-                    print(f"Guessed output format {format_class.name} for {self.output_file}")
+                    logging.info(f"Guessed output format {format_class.name} for {self.output_file}")
                     return
 
         raise TypeError(f"Unable to identify type of output file {self.output_file}")

--- a/src/ttblit/core/palette.py
+++ b/src/ttblit/core/palette.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import pathlib
 import struct
 
@@ -102,7 +103,7 @@ class Palette():
         self.width, self.height = palette.size
         if self.width * self.height > 256:
             raise argparse.ArgumentError(None, f'palette {palette_file} has too many pixels {self.width}x{self.height}={self.width*self.height} (max 256)')
-        print(f'Using palette {palette_file} {self.width}x{self.height}')
+        logging.info(f'Using palette {palette_file} {self.width}x{self.height}')
 
         self.image = palette.convert('RGBA')
 
@@ -111,7 +112,7 @@ class Palette():
             index = self.entries.index((r, g, b, a))
             return index
             # Noisy print
-            # print(f'Re-mapping ({r}, {g}, {b}, {a}) at ({x}x{y}) to ({index})')
+            # logging.info(f'Re-mapping ({r}, {g}, {b}, {a}) at ({x}x{y}) to ({index})')
         # Anything with 0 alpha that's not in the palette might as well be the transparent colour
         elif a == 0 and self.transparent is not None:
             return self.transparent

--- a/src/ttblit/core/tool.py
+++ b/src/ttblit/core/tool.py
@@ -1,3 +1,6 @@
+import logging
+
+
 class Tool():
     options = {}
 
@@ -31,7 +34,7 @@ class Tool():
         if output_file.exists() and not force:
             raise ValueError(f'Refusing to overwrite {output_file} (use force)')
         else:
-            print(f'Writing {output_file}')
+            logging.info(f'Writing {output_file}')
             if type(output_data) is str:
                 open(output_file, 'wb').write(output_data.encode('utf-8'))
             else:

--- a/src/ttblit/tool/cmake.py
+++ b/src/ttblit/tool/cmake.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 
 import yaml
@@ -40,11 +41,11 @@ class CMake(Tool):
             if args.config.is_file():
                 self.working_path = args.config.parent
             else:
-                print(f'Unable to find config at {args.config}')
+                logging.warning(f'Unable to find config at {args.config}')
 
         if args.config is not None:
             self.parse_config(args.config)
-            print(f'Using config at {args.config}')
+            logging.info(f'Using config at {args.config}')
 
         if args.output is not None:
             self.destination_path = args.output
@@ -63,7 +64,7 @@ class CMake(Tool):
             if target.suffix in AssetTarget.output_formats:
                 output_formatter = AssetTarget.output_formats[target.suffix]
             else:
-                print(f'Warning: Unable to guess type of {target}, assuming raw/binary')
+                logging.warning(f'Unable to guess type of {target}, assuming raw/binary')
                 output_formatter = AssetTarget.output_formats['.raw']
 
             if output_formatter.components is None:
@@ -84,7 +85,7 @@ class CMake(Tool):
                 else:
                     input_files = [file_glob]
                 if len(input_files) == 0:
-                    print(f'Warning: Input file(s) not found {self.working_path / file_glob}')
+                    logging.warning(f'Input file(s) not found {self.working_path / file_glob}')
                     continue
 
                 all_inputs += input_files

--- a/src/ttblit/tool/flasher.py
+++ b/src/ttblit/tool/flasher.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 
 import serial.tools.list_ports
@@ -33,7 +34,7 @@ class Flasher(Tool):
         ret = []
         for comport in serial.tools.list_ports.comports():
             if comport.vid == 0x0483 and comport.pid == 0x5740:
-                print(f'Found 32Blit on {comport.device}')
+                logging.info(f'Found 32Blit on {comport.device}')
                 ret.append(comport.device)
 
         if ret:
@@ -50,7 +51,7 @@ class Flasher(Tool):
         for comport in serial.tools.list_ports.comports():
             if comport.device == device:
                 if comport.vid == 0x0483 and comport.pid == 0x5740:
-                    print(f'Found 32Blit on {comport.device}')
+                    logging.info(f'Found 32Blit on {comport.device}')
                     return [device]
         raise RuntimeError(f'Unable to find 32Blit on {device}')
 
@@ -83,10 +84,10 @@ class Flasher(Tool):
                 directory = '/'
             else:
                 directory = f'{directory}/'
-            print(f'Saving {file} ({file_size} bytes) as {file_name} in {directory}')
+            logging.info(f'Saving {file} ({file_size} bytes) as {file_name} in {directory}')
             command = f'32BLSAVE{directory}{file_name}\x00{file_size}\x00'
         elif dest == 'flash':
-            print(f'Flashing {file} ({file_size} bytes)')
+            logging.info(f'Flashing {file} ({file_size} bytes)')
             command = f'32BLPROG{file_name}\x00{file_size}\x00'
 
         serial.reset_output_buffer()
@@ -123,5 +124,5 @@ class Flasher(Tool):
 
     @serial_command
     def run_reset(self, serial, args):
-        print('Resetting your 32Blit...')
+        logging.info('Resetting your 32Blit...')
         serial.write(b'32BL_RST\x00')

--- a/src/ttblit/tool/metadata.py
+++ b/src/ttblit/tool/metadata.py
@@ -1,7 +1,8 @@
 import argparse
+import binascii
+import logging
 import pathlib
 import struct
-import binascii
 from datetime import datetime
 
 import yaml
@@ -76,17 +77,17 @@ class Metadata(Tool):
                         bin = bin[:binary_size]
                     else:
                         raise ValueError(f'Invalid 32blit binary file {args.file}, expected {binary_size} bytes')
-                print(f'Using bin file at {args.file}')
+                logging.info(f'Using bin file at {args.file}')
             else:
                 raise ValueError(f'Invalid 32blit binary file {args.file}')
         else:
-            print(f'Unable to find bin file at {args.file}')
+            logging.warning(f'Unable to find bin file at {args.file}')
 
         if args.config.is_file():
             self.parse_config(args.config)
-            print(f'Using config at {args.config}')
+            logging.info(f'Using config at {args.config}')
         else:
-            print(f'Unable to find metadata config at {args.config}')
+            logging.warning(f'Unable to find metadata config at {args.config}')
 
         if 'icon' in self.config:
             icon = self.prepare_image_asset('icon', self.config['icon'])
@@ -126,10 +127,10 @@ class Metadata(Tool):
 
         if has_meta:
             if not args.force:
-                print(f'Refusing to overwrite metadata in {args.file}')
+                logging.critical(f'Refusing to overwrite metadata in {args.file}')
                 return 1
 
-        print(f'Adding metadata to {args.file}')
+        logging.info(f'Adding metadata to {args.file}')
         bin = bin + metadata
         open(args.file, 'wb').write(bin)
 

--- a/src/ttblit/tool/packer.py
+++ b/src/ttblit/tool/packer.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 
 import yaml
@@ -58,7 +59,7 @@ class Packer(Tool):
             if args.config.is_file():
                 self.working_path = args.config.parent
             else:
-                print(f'Unable to find config at {args.config}')
+                logging.warning(f'Unable to find config at {args.config}')
 
         if args.output is not None:
             self.destination_path = args.output
@@ -67,7 +68,7 @@ class Packer(Tool):
 
         if args.config is not None:
             self.parse_config(args.config)
-            print(f'Using config at {args.config}')
+            logging.info(f'Using config at {args.config}')
 
         elif args.files is not None and args.output is not None:
             self.filelist_to_config(args.files, args.output)
@@ -77,7 +78,7 @@ class Packer(Tool):
         # Top level of our config is filegroups and general settings
         for target, options in self.config.items():
             output_file = self.working_path / target
-            print(f'Preparing output target {output_file}')
+            logging.info(f'Preparing output target {output_file}')
 
             asset_sources = []
             target_options = {}
@@ -98,7 +99,7 @@ class Packer(Tool):
                 else:
                     input_files = [file_glob]
                 if len(input_files) == 0:
-                    print(f'Warning: Input file(s) not found {self.working_path / file_glob}')
+                    logging.warning(f'Input file(s) not found {self.working_path / file_glob}')
                     continue
 
                 # Rewrite a single string option to `name: option`
@@ -157,7 +158,7 @@ class AssetSource():
             for input_type, suffixes in asset_builder.typemap.items():
                 if file.suffix in suffixes:
                     return f'{command}/{input_type}'
-        print(f'Warning: Unable to guess type, assuming raw/binary {file}')
+        logging.warning(f'Unable to guess type, assuming raw/binary {file}')
         return 'raw/binary'
 
     def build(self, format, prefix=None, output_file=None):
@@ -192,7 +193,7 @@ class AssetSource():
             })
             builder.prepare_options(self.builder_options)
             output.append(builder.build())
-            print(f' - {self.type} {file} -> {builder.symbol_name}')
+            logging.info(f' - {self.type} {file} -> {builder.symbol_name}')
 
         return output
 
@@ -251,5 +252,5 @@ class AssetTarget():
     def guess_output_format(self, file):
         if file.suffix in self.output_formats:
             return self.output_formats[file.suffix]
-        print(f'Warning: Unable to guess type of {file}, assuming raw/binary')
+        logging.warning(f'Unable to guess type of {file}, assuming raw/binary')
         return RawBinary


### PR DESCRIPTION
This PR does two things:

1. Redirects error output to `stderr`
2. Re-route all `stdout` output through `logging` with new `-v` command to permit info and debug messages.

Should fix #8