### PR TITLE
Allow cmake tool to detect dependent files in arguments

### DIFF
--- a/src/ttblit/tool/cmake.py
+++ b/src/ttblit/tool/cmake.py
@@ -61,8 +61,6 @@ class CMake(Tool):
         for target, options in self.config.items():
             target = pathlib.Path(target)
 
-            print(options)
-
             if target.suffix in AssetTarget.output_formats:
                 output_formatter = AssetTarget.output_formats[target.suffix]
             else:


### PR DESCRIPTION
This is a bit of a rough and ready fix for #22 since it currently only supports the "palette" argument and doesn't parse the .yml config in enough detail to determine what kind of input data it should be looking for.

This may need to guess the input file type so that it can iterate through the `AssetBuilder.options` and detect `Path` and `Palette` types, but right now it works because - afaict - "palette" is the only additional file requirement used by any of the asset builders.