### PR TITLE
Include variables for metadata fields in the CMake file

### DIFF
--- a/src/tests/test_cmake.py
+++ b/src/tests/test_cmake.py
@@ -108,4 +108,12 @@ def test_cmake_no_depends(parsers, test_empty_metadata_file, test_cmake_file):
 
     cmake.run(args)
 
-    assert open(test_cmake_file.name).read() == '# Auto Generated File - DO NOT EDIT!'
+    assert open(test_cmake_file.name).read() == f'''# Auto Generated File - DO NOT EDIT!
+    set(METADATA_DEPENDS
+    
+    )
+    set(METADATA_TITLE "Rocks & Diamonds")
+    set(METADATA_AUTHOR "gadgetoid")
+    set(METADATA_DESCRIPTION "A pulse pounding, rock rollin', diamond hunting adventure")
+    set(METADATA_VERSION "v1.0.0")
+    '''

--- a/src/ttblit/tool/cmake.py
+++ b/src/ttblit/tool/cmake.py
@@ -76,16 +76,16 @@ class CMake(Tool):
             else:
                 all_inputs += list(self.working_path.glob(str(file)))
 
-        if len(all_inputs) == 0:
-            logging.warning(f'No input assets for metadata. Generating empty file {str(args.cmake)}')
-            open(args.cmake, 'w').write(f'# Auto Generated File - DO NOT EDIT!')
-        else:
-            all_inputs = '\n'.join(f'"{x}"'.replace('\\', '/') for x in all_inputs)
+        all_inputs = '\n'.join(f'"{x}"'.replace('\\', '/') for x in all_inputs)
 
-            open(args.cmake, 'w').write(f'''# Auto Generated File - DO NOT EDIT!
+        open(args.cmake, 'w').write(f'''# Auto Generated File - DO NOT EDIT!
     set(METADATA_DEPENDS
     {all_inputs}
     )
+    set(METADATA_TITLE "{self.config['title']}")
+    set(METADATA_AUTHOR "{self.config['author']}")
+    set(METADATA_DESCRIPTION "{self.config['description']}")
+    set(METADATA_VERSION "{self.config['version']}")
     ''')
 
     def run_for_asset_config(self, args):


### PR DESCRIPTION
Also removed the special case for no-inputs as an empty but set variable is valid and it was the easiest thing to do.