### PR TITLE
Don't require bin file for metadata tool

### DIFF
--- a/src/ttblit/tool/metadata.py
+++ b/src/ttblit/tool/metadata.py
@@ -26,7 +26,7 @@ class Metadata(Tool):
         Tool.__init__(self, parser)
         self.parser.add_argument('--config', type=pathlib.Path, help='Metadata config file')
         self.parser.add_argument('--icns', type=pathlib.Path, help='macOS icon output file')
-        self.parser.add_argument('--file', required=True, type=pathlib.Path, help='Input file')
+        self.parser.add_argument('--file', type=pathlib.Path, help='Input file')
         self.parser.add_argument('--force', action='store_true', help='Force file overwrite')
         self.parser.add_argument('--dump-images', action='store_true', help='Dump images from metadata')
 
@@ -103,17 +103,20 @@ class Metadata(Tool):
         return blit_icns.build({'data': image_bytes.read()})
 
     def run(self, args):
-        if not args.file.is_file():
+        if args.file and not args.file.is_file():
             raise ValueError(f'Unable to find bin file at {args.file}')
 
         icon = b''
         splash = b''
 
-        bin = open(args.file, 'rb').read()
-        try:
-            game = blit_game.parse(bin)
-        except StreamError:
-            raise ValueError(f'Invalid 32blit binary file {args.file}')
+        game = None
+
+        if args.file:
+            bin = open(args.file, 'rb').read()
+            try:
+                game = blit_game.parse(bin)
+            except StreamError:
+                raise ValueError(f'Invalid 32blit binary file {args.file}')
 
         # No config supplied, so dump the game info
         if args.config is None:
@@ -172,6 +175,10 @@ Parsed:      {args.file.name} ({game.bin.length:,} bytes)""")
                     logging.info(f'Saved macOS icon to {args.icns}')
         else:
             raise ValueError('A 128x96 pixel splash is required!"')
+
+
+        if not game:
+            return
 
         title = self.config.get('title')
         description = self.config.get('description')


### PR DESCRIPTION
When generating an icon for a macOS build, there isn't one. Possibly not the best way of handling this... Guess you would want to validate that at least one of `config` and `file` are specified. 

Allows this to work: https://github.com/Daft-Freak/32blit-beta/commit/5986dee904fbcf4abe1829167add74cf37523337