### PR TITLE
Use fresh class instances for each packed asset

### DIFF
--- a/src/tests/test_packer_cli.py
+++ b/src/tests/test_packer_cli.py
@@ -77,7 +77,6 @@ def test_packer_cli_relative_yml(parsers, tools, yml_file_relative_paths, output
     parser, subparser = parsers
 
     packer = packer.Packer(subparser)
-    packer.register_asset_builders(tools)
 
     args = parser.parse_args(['pack', '--force', '--config', yml_file_relative_paths.name, '--output', str(output_dir)])
 

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -14,7 +14,7 @@ deps =
 
 [testenv:qa]
 commands =
-	check-manifest --ignore tox.ini,tests*,.coveragerc
+	check-manifest --ignore tox.ini,tests/*,.coveragerc
 	python setup.py build sdist
 	twine check dist/*
 	flake8 --ignore E501

--- a/src/ttblit/__init__.py
+++ b/src/ttblit/__init__.py
@@ -35,13 +35,8 @@ def main():
     tools[map.MapAsset.command] = map.MapAsset(subparsers)
     tools[raw.RawAsset.command] = raw.RawAsset(subparsers)
 
-    _packer = packer.Packer(subparsers)
-
-    # Register the asset tools with the packer
-    _packer.register_asset_builders(tools)
-
     # Add the non-asset tools
-    tools[packer.Packer.command] = _packer
+    tools[packer.Packer.command] = packer.Packer(subparsers)
     tools[cmake.CMake.command] = cmake.CMake(subparsers)
     tools[flasher.Flasher.command] = flasher.Flasher(subparsers)
     tools[metadata.Metadata.command] = metadata.Metadata(subparsers)

--- a/src/ttblit/asset/font.py
+++ b/src/ttblit/asset/font.py
@@ -16,7 +16,7 @@ class FontAsset(AssetBuilder):
         'font': ('.ttf')  # possibly other freetype supported formats...
     }
 
-    def __init__(self, parser):
+    def __init__(self, parser=None):
         self.options.update({
             'height': (int, 0),
             'horizontal_spacing': (int, 1),
@@ -33,10 +33,11 @@ class FontAsset(AssetBuilder):
         self.base_char = ord(' ')
         self.num_chars = 96
 
-        self.parser.add_argument('--height', type=int, default=0, help='Font height (calculated from image if not specified)')
-        self.parser.add_argument('--horizontal-spacing', type=int, default=1, help='Additional space between characters for variable-width mode')
-        self.parser.add_argument('--vertical-spacing', type=int, default=1, help='Space between lines')
-        self.parser.add_argument('--space-width', type=int, default=1, help='Width of the space character')
+        if self.parser is not None:
+            self.parser.add_argument('--height', type=int, default=0, help='Font height (calculated from image if not specified)')
+            self.parser.add_argument('--horizontal-spacing', type=int, default=1, help='Additional space between characters for variable-width mode')
+            self.parser.add_argument('--vertical-spacing', type=int, default=1, help='Space between lines')
+            self.parser.add_argument('--space-width', type=int, default=1, help='Width of the space character')
 
     def prepare(self, args):
         AssetBuilder.prepare(self, args)

--- a/src/ttblit/asset/image.py
+++ b/src/ttblit/asset/image.py
@@ -17,7 +17,7 @@ class ImageAsset(AssetBuilder):
         'image': ('.png', '.gif')
     }
 
-    def __init__(self, parser):
+    def __init__(self, parser=None):
         self.options.update({
             'palette': (Palette, Palette()),
             'transparent': Colour,
@@ -32,10 +32,11 @@ class ImageAsset(AssetBuilder):
         self.packed = True
         self.strict = False
 
-        self.parser.add_argument('--palette', type=type_palette, default=None, help='Image or palette file of colours to use')
-        self.parser.add_argument('--transparent', type=Colour, help='Transparent colour')
-        self.parser.add_argument('--packed', type=str, nargs='?', default='yes', choices=('yes', 'no'), help='Pack into bits depending on palette colour count')
-        self.parser.add_argument('--strict', action='store_true', help='Reject colours not in the palette')
+        if self.parser is not None:
+            self.parser.add_argument('--palette', type=type_palette, default=None, help='Image or palette file of colours to use')
+            self.parser.add_argument('--transparent', type=Colour, help='Transparent colour')
+            self.parser.add_argument('--packed', type=str, nargs='?', default='yes', choices=('yes', 'no'), help='Pack into bits depending on palette colour count')
+            self.parser.add_argument('--strict', action='store_true', help='Reject colours not in the palette')
 
     def prepare(self, args):
         AssetBuilder.prepare(self, args)

--- a/src/ttblit/core/assetbuilder.py
+++ b/src/ttblit/core/assetbuilder.py
@@ -21,15 +21,17 @@ class AssetBuilder(Tool):
         'prefix': str
     }
 
-    def __init__(self, parser):
+    def __init__(self, parser=None):
         Tool.__init__(self, parser)
-        self.parser.add_argument('--input_file', type=pathlib.Path, required=True, help=f'Input file')
-        if(len(self.types) > 1):
-            self.parser.add_argument('--input_type', type=str, default=None, choices=self.types, help=f'Input file type')
-        self.parser.add_argument('--output_file', type=pathlib.Path, default=None)
-        self.parser.add_argument('--output_format', type=str, default=None, choices=self.formats.keys(), help=f'Output file format')
-        self.parser.add_argument('--symbol_name', type=str, default=None, help=f'Output symbol name')
-        self.parser.add_argument('--force', action='store_true', help=f'Force file overwrite')
+
+        if self.parser is not None:
+            self.parser.add_argument('--input_file', type=pathlib.Path, required=True, help=f'Input file')
+            if(len(self.types) > 1):
+                self.parser.add_argument('--input_type', type=str, default=None, choices=self.types, help=f'Input file type')
+            self.parser.add_argument('--output_file', type=pathlib.Path, default=None)
+            self.parser.add_argument('--output_format', type=str, default=None, choices=self.formats.keys(), help=f'Output file format')
+            self.parser.add_argument('--symbol_name', type=str, default=None, help=f'Output symbol name')
+            self.parser.add_argument('--force', action='store_true', help=f'Force file overwrite')
 
     def prepare(self, opts):
         """Imports a dictionary of options to class variables.

--- a/src/ttblit/core/tool.py
+++ b/src/ttblit/core/tool.py
@@ -4,8 +4,10 @@ import logging
 class Tool():
     options = {}
 
-    def __init__(self, parser):
-        self.parser = parser.add_parser(self.command, help=self.help)
+    def __init__(self, parser=None):
+        self.parser = None
+        if parser is not None:
+            self.parser = parser.add_parser(self.command, help=self.help)
 
     def prepare(self, opts):
         for option, option_type in self.options.items():


### PR DESCRIPTION
Previously a call to the `register_asset_builders` function was required when using the asset packer to register all the asset tools with the packer, these were then passed into an `AssetSource` instance where they were used to handle the build process of a single asset by "guessing" the appropriate tool.

Rather than faff around passing these from `__init__` all the way down to where they're used, this change defines the builders inside the `AssetSource` class. An instance is only created for a specific builder if it's used during a source `build`.

To make this change possible I've elminated the need to pass in a `parser` argument to `Tools`. IIRC the parser - which is used to set up `argparse` for handling tool arguments - is not used at all when invoking tools via the `AssetBuilder`.

This is a monster change which might break something... but - fingers crossed - the tests pass and 32blit-beta still builds.