### PR TITLE
Handle one asset to multiple outputs with different options

### DIFF
--- a/src/tests/test_packer_cli.py
+++ b/src/tests/test_packer_cli.py
@@ -109,3 +109,28 @@ def test_packer_cli_invalid_input(parsers, test_resources, output_dir):
     packer.run(args)
 
     assert packer.assets[0].sources[0].type == 'raw/binary'
+
+
+def test_packer_cli_multiple_outputs(parsers, test_resources, output_dir):
+    from ttblit.tool import packer
+
+    parser, subparser = parsers
+
+    packer = packer.Packer(subparser)
+
+    args = parser.parse_args([
+        'pack',
+        '--force',
+        '--config', str(test_resources / 'assets_multi_out.yml'),
+        '--output', output_dir
+    ])
+
+    packer.run(args)
+
+    assert (pathlib.Path(output_dir) / "assets.hpp").exists()
+    assert (pathlib.Path(output_dir) / "assets.cpp").exists()
+
+    hpp = open(pathlib.Path(output_dir) / "assets.hpp", "r").read()
+
+    assert "asset_image_packed" in hpp
+    assert "asset_image_raw" in hpp

--- a/src/tests/test_packer_cli/assets_multi_out.yml
+++ b/src/tests/test_packer_cli/assets_multi_out.yml
@@ -1,0 +1,8 @@
+assets.cpp:
+  prefix: asset_
+  image.png:
+    - name: image_packed
+      packed: true
+
+    - name: image_raw
+      packed: false

--- a/src/ttblit/tool/packer.py
+++ b/src/ttblit/tool/packer.py
@@ -105,9 +105,14 @@ class Packer(Tool):
                 elif file_options is None:
                     file_options = {}
 
-                asset_sources.append(
-                    AssetSource(input_files, file_options=file_options, working_path=self.working_path)
-                )
+                # Handle both an array of options dicts or a single dict
+                if type(file_options) is not list:
+                    file_options = [file_options]
+
+                for file_opts in file_options:
+                    asset_sources.append(
+                        AssetSource(input_files, file_options=file_opts, working_path=self.working_path)
+                    )
 
             self.assets.append(AssetTarget(
                 output_file,


### PR DESCRIPTION
This is so that you can do
```yaml
  assets/Comic_Sans_MS.ttf:
    - name: comic_font_12
      height: 12

    - name: comic_font_14
      height: 14
```
For the fun edge case that is fonts. Test maybe coming soon. (Definitely not just opening this PR so that the tests will run...)