### PR TITLE
Ensure RST is flushed to device before closing

### DIFF
--- a/src/ttblit/tool/flasher.py
+++ b/src/ttblit/tool/flasher.py
@@ -92,14 +92,17 @@ class Flasher(Tool):
 
     def _reset(self, serial, timeout=5.0):
         serial.write(b'32BL_RST\x00')
+        serial.flush()
         serial.close()
+        time.sleep(0.5)
         t_start = time.time()
         while time.time() - t_start < timeout:
             try:
                 serial.open()
-                break
+                return
             except SerialException:
                 time.sleep(0.1)
+        raise RuntimeError(f"Failed to connect to 32Blit on {serial.port} after reset")
 
     def _reset_to_firmware(self, serial):
         if self._get_status(serial) == 'game':
@@ -130,6 +133,7 @@ class Flasher(Tool):
             while sent_byte_count < file_size:
                 data = file.read(chunk_size)
                 serial.write(data)
+                serial.flush()
                 sent_byte_count += chunk_size
                 progress.update(chunk_size)
 


### PR DESCRIPTION
This fixes an apparent issue where - and I'm assuming here from observing the behaviour, not the actual serial data - the RST command was getting appended to the beginning of the subsequent command and causing the device to reset with an open serial connection. This shunts the device mid-flash from `ttyACM0` to `ttyAMC1` on my system and causes the flash operation to stall predictably at 3904 bytes.

This only happens when a reset is required from game to firmware state for flashing.

This might also fix the ol' stuck-the-end bug, too.

This PR also flushes after each chunk for good measure.