### PR TITLE
Fix 32blit thing.blit

### DIFF
--- a/src/ttblit/__init__.py
+++ b/src/ttblit/__init__.py
@@ -24,7 +24,7 @@ def main():
     if len(sys.argv) == 2:
         path = pathlib.Path(sys.argv[1])
         if path.suffix == '.blit':
-            sys.argv[1:] = ['flash', 'flash', '--file', str(path)]
+            sys.argv[1:] = ['flash', 'save', '--file', str(path)]
 
     if len(sys.argv) == 3:
         path = pathlib.Path(sys.argv[2])


### PR DESCRIPTION
It did the same thing as `32blit flash thing.blit` instead of saving to SD (like it used to do)