### PR TITLE
Tilemap layer names

### DIFF
--- a/src/tests/test_map.py
+++ b/src/tests/test_map.py
@@ -30,7 +30,7 @@ def test_map_tiled_struct_8bit():
 </map>
 ''', 'tiled', output_struct=True)
     # Tile indexes 1, 2, 3, 4 will be remapped -1 to 0, 1, 2, 3
-    assert output == struct.pack('<4sHHHHHH4B', b'MTMX', 16, 0, 0, 4, 1, 1, 0, 1, 2, 3)
+    assert output == struct.pack('<4sHHHHHH4B13s', b'MTMX', 16, 4, 0, 4, 1, 1, 0, 1, 2, 3, b'Tile Layer 1\0')
 
 
 def test_map_tiled_struct_16bit():
@@ -47,7 +47,7 @@ def test_map_tiled_struct_16bit():
 ''', 'tiled', output_struct=True)
     # Tile indexes 256, 257, 258, 259 will be remapped -1 to 255, 256, 257, 258
     # output tile data will be 16bit!
-    assert output == struct.pack('<4sHHHHHH4H', b'MTMX', 16, 1, 0, 4, 1, 1, 255, 256, 257, 258)
+    assert output == struct.pack('<4sHHHHHH4H13s', b'MTMX', 16, 5, 0, 4, 1, 1, 255, 256, 257, 258, b'Tile Layer 1\0')
 
 
 def test_map_tiled_layer_reorder():
@@ -67,7 +67,7 @@ def test_map_tiled_layer_reorder():
  </layer>
 </map>
 ''', 'tiled', output_struct=True)
-    assert output == struct.pack('<4sHHHHHH8B', b'MTMX', 16, 0, 0, 4, 1, 2, 0, 1, 2, 3, 4, 5, 6, 7)
+    assert output == struct.pack('<4sHHHHHH8B26s', b'MTMX', 16, 4, 0, 4, 1, 2, 0, 1, 2, 3, 4, 5, 6, 7, b'Tile Layer 1\0Tile Layer 2\0')
 
 
 def test_map_empty_tiled_remap_empty():

--- a/src/ttblit/asset/builders/map.py
+++ b/src/ttblit/asset/builders/map.py
@@ -20,6 +20,7 @@ def tiled_to_binary(data, empty_tile, output_struct):
     layers = root.findall('layer')
     layer_data = []
     transform_data = []
+    layer_names = []
     # Sort layers by ID (since .tmx files can have them in arbitrary orders)
     layers.sort(key=lambda l: int(l.get('id')))
 
@@ -43,6 +44,8 @@ def tiled_to_binary(data, empty_tile, output_struct):
         layer_data += layer
         transform_data += layer_transforms
 
+        layer_names.append(layer_csv.attrib['name'])
+
     if use_16bits:
         layer_data = struct.pack(f'<{len(layer_data)}H', *layer_data)
     else:
@@ -65,6 +68,10 @@ def tiled_to_binary(data, empty_tile, output_struct):
         else:
             transform_data = []
 
+        # append layer names at the very end
+        name_data = b'\0'.join([x.encode() for x in layer_names]) + b'\0'
+        flags |= (1 << 2) # have names
+
         return struct.pack(
             '<4sHHHHHH',
             bytes('MTMX', encoding='utf-8'),
@@ -74,7 +81,7 @@ def tiled_to_binary(data, empty_tile, output_struct):
             width,
             height,
             layer_count
-        ) + layer_data + bytes(transform_data)
+        ) + layer_data + bytes(transform_data) + name_data
 
     else:
         # Just return the raw layer data


### PR DESCRIPTION
Appends the names after the tile/transform data if generating a struct. Thought about adding the offset to the header, but there's code out there using a customised header struct that would get broken (despite the existence of the `header_length` field)...